### PR TITLE
Support `/*!no*/` comments syntax to fix issues #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ node_modules
 
 # Others
 .DS_Store
+
+# Intellij & WebStorm
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ One raw stylesheet: `test.css`
   height: 64px; /*px*/
   font-size: 28px; /*px*/
   border: 1px solid #ddd; /*no*/
+  margin-left: 5px; /*!no*/
 }
 ```
 
@@ -90,6 +91,7 @@ Rem version: `test.debug.css`
 .selector {
   width: 2rem;
   border: 1px solid #ddd;
+  margin-left: 5px;
 }
 [data-dpr="1"] .selector {
   height: 32px;
@@ -113,6 +115,7 @@ Rem version: `test.debug.css`
   height: 32px;
   font-size: 14px;
   border: 1px solid #ddd;
+  margin-left: 5px;
 }
 ```
 
@@ -124,6 +127,7 @@ Rem version: `test.debug.css`
   height: 64px;
   font-size: 28px;
   border: 1px solid #ddd;
+  margin-left: 5px;
 }
 ```
 
@@ -135,6 +139,7 @@ Rem version: `test.debug.css`
   height: 96px;
   font-size: 42px;
   border: 1px solid #ddd;
+  margin-left: 5px;
 }
 ```
 
@@ -143,6 +148,10 @@ Rem version: `test.debug.css`
 comment hook + css parser
 
 ## Change Log
+
+### 0.5.1
+
+* Support less-loader on webpack (using `/*!no*/`)
 
 ### 0.5.0
 

--- a/lib/px2rem.js
+++ b/lib/px2rem.js
@@ -45,7 +45,9 @@ Px2rem.prototype.generateThree = function (cssText, dpr) {
         if (declaration.type === 'declaration' && pxRegExp.test(declaration.value)) {
           var nextDeclaration = rule.declarations[j + 1];
           if (nextDeclaration && nextDeclaration.type === 'comment') { // next next declaration is comment
-            if (nextDeclaration.comment.trim() === config.keepComment) { // no transform
+            if (nextDeclaration.comment.trim() === config.keepComment
+              || nextDeclaration.comment.trim() === '!' + config.keepComment
+            ) { // no transform
               declarations.splice(j + 1, 1); // delete corresponding comment
               continue;
             } else if (nextDeclaration.comment.trim() === config.forcePxComment) { // force px
@@ -101,7 +103,7 @@ Px2rem.prototype.generateRem = function (cssText) {
         var declaration = declarations[j];
         // need transform: declaration && has 'px'
         if (declaration.type === 'declaration' && pxRegExp.test(declaration.value)) {
-          var nextDeclaration = declarations[j + 1];
+          var nextDeclaration = rule.declarations[j + 1];
           if (nextDeclaration && nextDeclaration.type === 'comment') { // next next declaration is comment
             if (nextDeclaration.comment.trim() === config.forcePxComment) { // force px
               // do not transform `0px`
@@ -124,7 +126,9 @@ Px2rem.prototype.generateRem = function (cssText) {
                 declaration.value = self._getCalcValue('rem', declaration.value); // common transform
                 declarations.splice(j + 1, 1); // delete corresponding comment
               }
-            } else if (nextDeclaration.comment.trim() === config.keepComment) { // no transform
+            } else if (nextDeclaration.comment.trim() === config.keepComment
+              || nextDeclaration.comment.trim() === '!' + config.keepComment
+            ) { // no transform
               declarations.splice(j + 1, 1); // delete corresponding comment
             } else {
               declaration.value = self._getCalcValue('rem', declaration.value); // common transform

--- a/test/assets/test.2x.css
+++ b/test/assets/test.2x.css
@@ -16,6 +16,7 @@ body {
 }
 .main {
   height: 400px;
+  border: 1px solid; /*!no*/
 }
 .sidebar {
   margin: 0;

--- a/test/assets/test.3x.css
+++ b/test/assets/test.3x.css
@@ -16,6 +16,7 @@ body {
 }
 .main {
   height: 600px;
+  border: 1px solid; /*!no*/
 }
 .sidebar {
   margin: 0;

--- a/test/output/default.1x.css
+++ b/test/output/default.1x.css
@@ -21,6 +21,7 @@ body {
 
 .main {
   height: 200px;
+  border: 1px solid;
 }
 
 .sidebar {

--- a/test/output/default.2x.css
+++ b/test/output/default.2x.css
@@ -21,6 +21,7 @@ body {
 
 .main {
   height: 400px;
+  border: 1px solid;
 }
 
 .sidebar {

--- a/test/output/default.3x.css
+++ b/test/output/default.3x.css
@@ -21,6 +21,7 @@ body {
 
 .main {
   height: 600px;
+  border: 1px solid;
 }
 
 .sidebar {

--- a/test/output/default.rem.css
+++ b/test/output/default.rem.css
@@ -48,6 +48,7 @@ body {
 
 .main {
   height: 5.333333rem;
+  border: 1px solid;
 }
 
 .sidebar {


### PR DESCRIPTION
提供 `/*!no*/`  的注释语法，用于支持`less-loader`。

请容我解释一下为何在`px2rem`内部兼容，而不是去修复 webpack 或者 less-loader：
- less-loader 在 webpack 压缩时，会过滤默认的 CSS 注释，但提供了一种保留办法 `/*!`（据我所知，也是唯一的办法）: 
  - [It is possible to compress LESS files without removing comments using lessc?](http://stackoverflow.com/questions/18369307/it-is-possible-to-compress-less-files-without-removing-comments-using-lessc)
- `!` 符号在 webpack 的 loader 语法上是模块关键字：
  - [less-loader Usage](https://github.com/webpack/less-loader#usage)
- 这导致了 px2rem-loader 无法使用 query 传递 `px2rem?keepComment=!no`（必然报错）
  - [px2rem-loader webpack config](https://github.com/Jinjiang/px2rem-loader#webpack-config)

必须通过 `!` 兼容 Less.js 的 source-map ，而在 webpack loader 体系不能传递 `!`，这就陷入一个死循环。

我承认这个 PR 不是最优雅的做法，但在不修改 YUI Compress 标准，又不变化 Webpack 1.x 体系的前提下，在内部支持可能是代价最小却能解决实际问题的做法。

@songsiqi  @Jinjiang 怎么看 ^_^？
