### PR TITLE
modify keepComment and forcePxComment because uglifyJsPlugin defaults…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ node_modules
 
 # Others
 .DS_Store
+.tags
+.tags1

--- a/lib/px2rem.js
+++ b/lib/px2rem.js
@@ -7,8 +7,8 @@ var defaultConfig = {
   baseDpr: 2,             // base device pixel ratio (default: 2)
   remUnit: 75,            // rem unit value (default: 75)
   remPrecision: 6,        // rem value precision (default: 6)
-  forcePxComment: 'px',   // force px comment (default: `px`)
-  keepComment: 'no'       // no transform value comment (default: `no`)
+  forcePxComment: '!px',   // force px comment (default: `px`)
+  keepComment: '!no'       // no transform value comment (default: `no`)
 };
 
 var pxRegExp = /\b(\d+(\.\d+)?)px\b/;


### PR DESCRIPTION
… to preserving comments containing /*!, /**!