### PR TITLE
add regExp match value start with point, e.g .5px

### DIFF
--- a/lib/px2rem.js
+++ b/lib/px2rem.js
@@ -11,7 +11,7 @@ var defaultConfig = {
   keepComment: 'no'       // no transform value comment (default: `no`)
 };
 
-var pxRegExp = /\b(\d+(\.\d+)?)px\b/;
+var pxRegExp = /^((\.\d+)|(\d+(\.\d+)?))px$/;
 
 function Px2rem(options) {
   this.config = {};


### PR DESCRIPTION
fix value start with point match error
for example .5px was used 5 to transfer to rem