### PR TITLE
fix: 处理.5px等忽略小数首位0时rem计算异常的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 
 # Others
 .DS_Store
+.idea

--- a/lib/px2rem.js
+++ b/lib/px2rem.js
@@ -11,7 +11,7 @@ var defaultConfig = {
   keepComment: 'no'       // no transform value comment (default: `no`)
 };
 
-var pxRegExp = /\b(\d+(\.\d+)?)px\b/;
+var pxRegExp = /(?<=^|\s+|\b)(\d*\.?\d*)px\b/;
 
 function Px2rem(options) {
   this.config = {};

--- a/test/px2rem.test.js
+++ b/test/px2rem.test.js
@@ -64,3 +64,32 @@ describe('should work with @3x origin css file', function () {
     assert.equal(outputText, fs.readFileSync(expectedPath, {encoding: 'utf8'}));
   });
 });
+
+describe('Px2rem.prototype._getCalcValue rem', function () {
+  var px2remIns = new Px2rem({remUnit: 100});
+  it('normal number px', function () {
+    var outputText = px2remIns._getCalcValue('rem', '10px 20px')
+    assert.equal('0.1rem 0.2rem', outputText)
+  })
+
+  it('float number px', function () {
+    var outputText = px2remIns._getCalcValue('rem', '0.5px solid #000')
+    assert.equal('0.005rem solid #000', outputText)
+    var outputText2 = px2remIns._getCalcValue('rem', '0.5px 11.5px')
+    assert.equal('0.005rem 0.115rem', outputText2)
+  })
+
+  it('float number px ignore first zero', function () {
+    var outputText =  px2remIns._getCalcValue('rem', '.5px solid #000')
+    assert.equal('0.005rem solid #000', outputText)
+
+    var outputText2 = px2remIns._getCalcValue('rem', ' .5px solid #000')
+    assert.equal(' 0.005rem solid #000', outputText2)
+
+    var outputText3 = px2remIns._getCalcValue('rem', 'solid .5px #000')
+    assert.equal('solid 0.005rem #000', outputText3)
+
+    var outputText4 = px2remIns._getCalcValue('rem', 'solid #000 .5px')
+    assert.equal('solid #000 0.005rem', outputText4)
+  })
+});


### PR DESCRIPTION
使用dart-sass时，当outputStyle配置项为压缩模式，会将`0.5px`等小于1的数字忽略首位0，最终输入`.5px`，

这种数字单位在`px2rem`时会错误地忽略小数点`.`，被当做成`5px`，比如当remUnit为100时，计算输出的rem值变成了`.0.05rem`，导致最后的结果变成了`0.05rem`，结果扩大了10倍，因此需要修复一下
